### PR TITLE
Fix compatibility with Python 3

### DIFF
--- a/ipaddr.py
+++ b/ipaddr.py
@@ -25,6 +25,11 @@ and networks.
 __version__ = 'trunk'
 
 import struct
+import sys
+
+if sys.version_info > (3,):
+    long = int
+    xrange = range
 
 IPV4LENGTH = 32
 IPV6LENGTH = 128
@@ -1486,7 +1491,7 @@ class _BaseV6(object):
 
         try:
             # Now, parse the hextets into a 128-bit integer.
-            ip_int = 0L
+            ip_int = long(0)
             for i in xrange(parts_hi):
                 ip_int <<= 16
                 ip_int |= self._parse_hextet(parts[i])

--- a/ipaddr_test.py
+++ b/ipaddr_test.py
@@ -22,6 +22,10 @@ import time
 import unittest
 
 import ipaddr
+import sys
+
+if sys.version_info > (3,):
+    long = int
 
 # Compatibility function to cast str to bytes objects
 if issubclass(ipaddr.Bytes, str):
@@ -275,7 +279,7 @@ class IpaddrUnitTest(unittest.TestCase):
                          '2001:658:22a:cafe:200::1')
 
     def testGetNetmask(self):
-        self.assertEqual(int(self.ipv4.netmask), 4294967040L)
+        self.assertEqual(int(self.ipv4.netmask), 4294967040)
         self.assertEqual(str(self.ipv4.netmask), '255.255.255.0')
         self.assertEqual(str(self.ipv4_hostmask.netmask), '255.0.0.0')
         self.assertEqual(int(self.ipv6.netmask),
@@ -292,7 +296,7 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertEqual(ipv6_zero_netmask._prefix_from_prefix_string('0'), 0)
 
     def testGetBroadcast(self):
-        self.assertEqual(int(self.ipv4.broadcast), 16909311L)
+        self.assertEqual(int(self.ipv4.broadcast), 16909311)
         self.assertEqual(str(self.ipv4.broadcast), '1.2.3.255')
 
         self.assertEqual(int(self.ipv6.broadcast),
@@ -1159,9 +1163,9 @@ class IpaddrUnitTest(unittest.TestCase):
 
     def testNetworkElementCaching(self):
         # V4 - make sure we're empty
-        self.assertFalse(self.ipv4._cache.has_key('network'))
-        self.assertFalse(self.ipv4._cache.has_key('broadcast'))
-        self.assertFalse(self.ipv4._cache.has_key('hostmask'))
+        self.assertFalse('network' in self.ipv4._cache)
+        self.assertFalse('broadcast' in self.ipv4._cache)
+        self.assertFalse('hostmask' in self.ipv4._cache)
 
         # V4 - populate and test
         self.assertEqual(self.ipv4.network, ipaddr.IPv4Address('1.2.3.0'))
@@ -1169,14 +1173,14 @@ class IpaddrUnitTest(unittest.TestCase):
         self.assertEqual(self.ipv4.hostmask, ipaddr.IPv4Address('0.0.0.255'))
 
         # V4 - check we're cached
-        self.assertTrue(self.ipv4._cache.has_key('network'))
-        self.assertTrue(self.ipv4._cache.has_key('broadcast'))
-        self.assertTrue(self.ipv4._cache.has_key('hostmask'))
+        self.assertTrue('network' in self.ipv4._cache)
+        self.assertTrue('broadcast' in self.ipv4._cache)
+        self.assertTrue('hostmask' in self.ipv4._cache)
 
         # V6 - make sure we're empty
-        self.assertFalse(self.ipv6._cache.has_key('network'))
-        self.assertFalse(self.ipv6._cache.has_key('broadcast'))
-        self.assertFalse(self.ipv6._cache.has_key('hostmask'))
+        self.assertFalse('network' in self.ipv6._cache)
+        self.assertFalse('broadcast' in self.ipv6._cache)
+        self.assertFalse('hostmask' in self.ipv6._cache)
 
         # V6 - populate and test
         self.assertEqual(self.ipv6.network,
@@ -1187,9 +1191,9 @@ class IpaddrUnitTest(unittest.TestCase):
                          ipaddr.IPv6Address('::ffff:ffff:ffff:ffff'))
 
         # V6 - check we're cached
-        self.assertTrue(self.ipv6._cache.has_key('network'))
-        self.assertTrue(self.ipv6._cache.has_key('broadcast'))
-        self.assertTrue(self.ipv6._cache.has_key('hostmask'))
+        self.assertTrue('network' in self.ipv6._cache)
+        self.assertTrue('broadcast' in self.ipv6._cache)
+        self.assertTrue('hostmask' in self.ipv6._cache)
 
     def testTeredo(self):
         # stolen from wikipedia


### PR DESCRIPTION
This is a trivial fix that makes ipaddr-py work with Python 3. Now, I know Python 3 has ipaddress module, but I see no reason why ipaddr-py should not be made working under Python 3 as well, especially since the fix is so simple, unless I'm missing something non-obvious.

This set of patches was made to make "devel/py-ipaddr" port on FreeBSD buildable with Python 3 (currently a proposal only, please see https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=205907 ), patches against ipaddr-2.1.11 from PyPi.